### PR TITLE
Add heroku-postbuild script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
         "start": "node ./src/server/server.js",
         "watch": "nodemon --config nodemon.json",
         "dev": "webpack --config webpack.config.js",
-        "prod": "NODE_ENV=production webpack --config webpack.config.js --progress"
+        "prod": "NODE_ENV=production webpack --config webpack.config.js --progress",
+        "heroku-postbuild": "npm run prod"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
Now that the `bundle.js` and `main.min.css` files are removed from the repo, we need to get Heroku to rebuild them before it starts the server. 
Based on the steps outlined in [this page](https://codeburst.io/deploy-your-webpack-apps-to-heroku-in-3-simple-steps-4ae072af93a8), this can be done by adding a `heroku-postbuild` script that runs the webpack build.